### PR TITLE
feat: add support for JBang options in JBangTask and update documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ following properties
 |===
 | Property   | Type         | Option        | System            | Environment       | Default                         | Required
 | script     | String       | jbang-script  | jbang.script      | JBANG_SCRIPT      |                                 | {required-icon}
-| jbangArgs  | List<String> | jbang-jbangArgs | jbang.jbangArgs | JBANG_JBANG_ARGS  | [ ]                             | {optional-icon}
+| jbangArgs  | List<String> | jbang-jbang-args | jbang.jbangArgs | JBANG_JBANG_ARGS  | [ ]                             | {optional-icon}
 | args       | List<String> | jbang-args    | jbang.args        | JBANG_ARGS        | [ ]                             | {optional-icon}
 | trusts     | List<String> | jbang-trusts  | jbang.trusts      | JBANG_TRUSTS      | [ ]                             | {optional-icon}
 | version    | String       | jbang-version | jbang.version     | JBANG_VERSION     | latest                          | {optional-icon}

--- a/src/main/groovy/dev/jbang/gradle/tasks/JBangTask.groovy
+++ b/src/main/groovy/dev/jbang/gradle/tasks/JBangTask.groovy
@@ -98,7 +98,7 @@ class JBangTask extends DefaultTask {
         getVersion().set(version)
     }
 
-    @Option(option = 'jbang-jbangArgs', description = 'JBang arguments to be used by JBang when running the script (if any) (OPTIONAL).')
+    @Option(option = 'jbang-jbang-args', description = 'JBang arguments to be used by JBang when running the script (if any) (OPTIONAL).')
     void setJbangArgs(String jbangArgs) {
         if (jbangArgs) getJbangArgs().set(jbangArgs.split(',').toList())
     }


### PR DESCRIPTION
This PR adds `options` for the JBang command. They would be prepended to the `script` so it can be customized.

This would solve #5 

Rationale: being able to add extra dependencies when running a remote script

Right now I'm using the workarround of prepending them to the script

```kotlin
tasks.register<dev.jbang.gradle.tasks.JBangTask>("generateAsyncApiProvider") {
    group = "zenwave"
    description = "Generates Spring Cloud Streams code from AsyncAPI specification"
    script.set("--deps=org.slf4j:slf4j-simple:1.7.36,io.zenwave360.sdk.plugins:asyncapi-spring-cloud-streams3:RELEASE io.zenwave360.sdk:zenwave-sdk-cli:RELEASE")
    args.set(listOf(

    ))
}
```

After this PR:

```kotlin
tasks.register<dev.jbang.gradle.tasks.JBangTask>("generateAsyncApiProvider") {
    group = "zenwave"
    description = "Generates Spring Cloud Streams code from AsyncAPI specification"
    script.set("io.zenwave360.sdk:zenwave-sdk-cli:RELEASE")
    options.set(listOf(
       "--deps=org.slf4j:slf4j-simple:1.7.36,io.zenwave360.sdk.plugins:asyncapi-spring-cloud-streams3:RELEASE"
    ))
    args.set(listOf(

    ))
}
```


**NOTE:** This is a blind PR as I could not build the project locally due to missing dependencies

```log
Could not resolve all artifacts for configuration 'classpath'.
> Could not find org.kordamp.gradle:enforcer-api:0.9.0.
  Searched in the following locations:
    - https://plugins.gradle.org/m2/org/kordamp/gradle/enforcer-api/0.9.0/enforcer-api-0.9.0.pom
    - https://repo.maven.apache.org/maven2/org/kordamp/gradle/enforcer-api/0.9.0/enforcer-api-0.9.0.pom
    - file:/C:/Users/ivan.garcia/.m2/repository/org/kordamp/gradle/enforcer-api/0.9.0/enforcer-api-0.9.0.pom
  Required by:
      unspecified:unspecified:unspecified > org.kordamp.gradle:kordamp-parentbuild:2.3.0
      unspecified:unspecified:unspecified > org.kordamp.gradle:kordamp-parentbuild:2.3.0 > org.kordamp.gradle:enforcer-gradle-plugin:0.9.0
```
