### PR TITLE
Enable gradle fingerprinting

### DIFF
--- a/src/main/groovy/dev/jbang/gradle/tasks/JBangTask.groovy
+++ b/src/main/groovy/dev/jbang/gradle/tasks/JBangTask.groovy
@@ -158,8 +158,7 @@ class JBangTask extends DefaultTask {
         trusts.provider
     }
 
-    @Input
-    @Optional
+    @Internal
     Provider<Directory> getResolvedInstallDir() {
         installDir.provider
     }


### PR DESCRIPTION
I could not use this plugin with gradle caching enabled. -> Fixes https://github.com/jbangdev/jbang-gradle-plugin/issues/7.

This is kind of a hot fix for this.

I left the other `getResolved...` methods untouched.