### PR TITLE
fix: Handle spaces in the path to the script

### DIFF
--- a/src/main/groovy/dev/jbang/gradle/tasks/JBangTask.groovy
+++ b/src/main/groovy/dev/jbang/gradle/tasks/JBangTask.groovy
@@ -281,12 +281,12 @@ class JBangTask extends DefaultTask {
 
     private void executeJBang() {
         List<String> command = command()
-        StringBuilder executable = new StringBuilder(findJBangExecutable())
-        executable.append(' run ').append(getResolvedScript().get())
+        command.add(findJBangExecutable())
+        command.add("run")
+        command.add(getResolvedScript().get())
         if (getResolvedArgs().get()) {
-            executable.append(' ').append(String.join(' ', getResolvedArgs().get()))
+            command.addAll(getResolvedArgs().get())
         }
-        command.add(executable.toString())
         ProcessResult result = execute(command)
         if (result.getExitValue() != 0) {
             throw new IllegalStateException('Error while executing JBang. Exit code: ' + result.getExitValue())


### PR DESCRIPTION
When a user has its user name **with** spaces, JBang cannot find the script.

Example:

    C:\Users\demo user\scripts\helloworld.java

Result:

    [jbang] [ERROR]  Script or alieas could not be found or read: 'C:\Users\demo'

This PR fixes this by using [ZT Process Executor](https://github.com/zeroturnaround/zt-exec)'s API as outlined at [their examples](https://github.com/zeroturnaround/zt-exec?tab=readme-ov-file#examples).