### PR TITLE
Fix: Spaces in script names also work in sh -c environments

### DIFF
--- a/src/main/groovy/dev/jbang/gradle/tasks/JBangTask.groovy
+++ b/src/main/groovy/dev/jbang/gradle/tasks/JBangTask.groovy
@@ -281,12 +281,13 @@ class JBangTask extends DefaultTask {
 
     private void executeJBang() {
         List<String> command = command()
-        command.add(findJBangExecutable())
-        command.add("run")
-        command.add(getResolvedScript().get())
+        // A single string is needed, because if "sh -c jbang" is used for execution, the parameters need to be passed as single string
+        StringBuilder executable = new StringBuilder(findJBangExecutable())
+        executable.append(' run ').append("\"").append(getResolvedScript().get()).append("\"")
         if (getResolvedArgs().get()) {
-            command.addAll(getResolvedArgs().get())
+            executable.append(' ').append(String.join(' ', getResolvedArgs().get()))
         }
+        command.add(executable.toString())
         ProcessResult result = execute(command)
         if (result.getExitValue() != 0) {
             throw new IllegalStateException('Error while executing JBang. Exit code: ' + result.getExitValue())


### PR DESCRIPTION
Follow-up to https://github.com/jbangdev/jbang-gradle-plugin/pull/17

On the CI, I had

```
Found JBang v.0.126.3

jbang command = [sh, -c, jbang, run, /home/runner/work/jabref/jabref/build-support/src/main/java/CitationStyleCatalogGenerator.java]

jbang is a tool for building and running .java/.jsh scripts and jar packages.
Usage: jbang [-hV] [--insecure] [--preview] [--config=<config>] [--verbose |
    --quiet] [-o | --fresh] [COMMAND]
```

It turned out that `sh -c jbang` has some "other" CLI arguments handling as "normal" CLIs.

Changed:

1. Added a comment on the why we use a StringBuilder
2. Enclosed script name in quotes

Not done: Enclosing script parameters in quotes, because I fear the risk of side effects.