### PR TITLE
fix: Put marker file into gradleUserHomeDir directory (instead of .cache)

### DIFF
--- a/src/main/groovy/dev/jbang/gradle/Banner.groovy
+++ b/src/main/groovy/dev/jbang/gradle/Banner.groovy
@@ -67,7 +67,7 @@ abstract class Banner implements BuildService<Params> {
 
         boolean printBanner = null == System.getProperty(ORG_KORDAMP_BANNER) || Boolean.getBoolean(ORG_KORDAMP_BANNER)
 
-        File parent = new File(gradle.gradleUserHomeDir, 'caches')
+        File parent = new File(gradle.gradleUserHomeDir, '.tmp')
         File markerFile = getMarkerFile(parent)
         if (!markerFile.exists()) {
             markerFile.parentFile.mkdirs()

--- a/src/main/groovy/dev/jbang/gradle/Banner.groovy
+++ b/src/main/groovy/dev/jbang/gradle/Banner.groovy
@@ -67,7 +67,7 @@ abstract class Banner implements BuildService<Params> {
 
         boolean printBanner = null == System.getProperty(ORG_KORDAMP_BANNER) || Boolean.getBoolean(ORG_KORDAMP_BANNER)
 
-        File parent = new File(gradle.gradleUserHomeDir, '.tmp')
+        File parent = new File(gradle.gradleUserHomeDir)
         File markerFile = getMarkerFile(parent)
         if (!markerFile.exists()) {
             markerFile.parentFile.mkdirs()

--- a/src/main/groovy/dev/jbang/gradle/Banner.groovy
+++ b/src/main/groovy/dev/jbang/gradle/Banner.groovy
@@ -67,7 +67,7 @@ abstract class Banner implements BuildService<Params> {
 
         boolean printBanner = null == System.getProperty(ORG_KORDAMP_BANNER) || Boolean.getBoolean(ORG_KORDAMP_BANNER)
 
-        File parent = new File(gradle.gradleUserHomeDir)
+        File parent = gradle.gradleUserHomeDir
         File markerFile = getMarkerFile(parent)
         if (!markerFile.exists()) {
             markerFile.parentFile.mkdirs()


### PR DESCRIPTION
When running the plugin, I get following output

    Calculating task graph as configuration cache cannot be reused because file '..\..\Users\olive\.gradle\caches\kordamp\jbang\0.4.0-SNAPSHOT\marker.txt' has changed

The claim is true - the file seems to be modified on each run.

Proposal: Treat the file as temporary file - in most cases, this will lead to the same results.

(Side track: We are using the release build, but still `-SNAPSHOT` is output. Not sure why)