### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,10 +33,10 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 11
           distribution: zulu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: kordamp/kordamp-gradle-plugin-workflow/.github/workflows/release.yml@main
+    uses: kordamp/kordamp-gradle-plugin-workflow/.github/workflows/release.yml@fc243bee70daa2b341d9365129e2c8f14192e17b # main
     with:
       jreleaser-version: latest
       version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
Pin all action references to full-length commit SHAs for supply chain security.

This is required for enabling the org-level policy:
**Require actions to be pinned to a full-length commit SHA**

Original version tags are preserved as comments for readability.
Consider adding Dependabot for GitHub Actions to keep pins updated:

```yaml
# .github/dependabot.yml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow reliability through configuration updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbangdev/jbang-gradle-plugin/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->